### PR TITLE
Remove invalid options

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -57,7 +57,6 @@ bind -r L resize-pane -R 5
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"  
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 
-set -g mouse-utf8 on
 set -g mouse on
 
 # From: http://www.hamvocke.com/blog/a-guide-to-customizing-your-tmux-conf/
@@ -71,7 +70,6 @@ set -g pane-active-border-fg brightred
 
 ## Status bar design
 # status line
-set -g status-utf8 on
 set -g status-justify left
 set -g status-bg default
 set -g status-fg colour12


### PR DESCRIPTION
These 2 options are removed after tmux 2.2, utf8 is default on.